### PR TITLE
Pre-Populate Sprint Cache To Address Rate Limits

### DIFF
--- a/controllers/sprints/sprintManager.js
+++ b/controllers/sprints/sprintManager.js
@@ -45,6 +45,49 @@ export const getSprintLogForProjectName = async (projectName) => {
 };
 
 /**
+ * Pre-populates sprint cache with parsed sprint log data.
+ * @return {Promise<void>}
+ */
+export const prepopulateSprintCache = async () => {
+  // get all projects
+  let allProjects = await Project.find({}).exec();
+
+  // create an array of promises to push data to cache
+  let cacheUpdatePromises = [];
+  for (let project of allProjects) {
+    // TODO: this should all be in a separate function that is async
+    // get current sprint log url
+    let sprintUrl = project["sprint_log"];
+    let lastEditDate = await getSprintLogLastUpdate(sprintUrl);
+    console.log(`Last Edit Date for ${ project["name"] } Sprint Log: ${ lastEditDate }`);
+
+    // check cache first for the sprint log
+    let cachedSprintLog = await getCachedSprintLog(project);
+    if (cachedSprintLog !== undefined) {
+      // check if cached sprint log is still relevant
+      let cacheData = cachedSprintLog['data'];
+      let cacheDate = cachedSprintLog['last_modified'];
+
+      // check if version in cache is most recent; if not, remove instance
+      if (lastEditDate <= cacheDate) {
+        console.log(`Sprint Cache HIT for project ${ project['name'] }. Will not refresh cache.`);
+      }
+    }
+
+    // cache miss -- get parsed sprint log
+    console.log(`Sprint Cache MISS for project ${ project['name'] }`);
+    let parsedSprintLog = await new SprintLog(sprintUrl);
+
+    // add to cache
+    if (cachedSprintLog !== undefined) {
+      await updateCachedSprintLog(cachedSprintLog, parsedSprintLog, lastEditDate);
+    } else {
+      await addSprintToCache(project._id, parsedSprintLog, lastEditDate);
+    }
+  }
+};
+
+/**
  * Fetches a sprint log for a project.
  * Checks to see if the project is stored in the cache first before parsing a new one from GDrive.
  * @param project

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ import { prepopulateSprintCache } from "./controllers/sprints/sprintManager.js";
 const PORT = process.env.PORT || 3000;
 const MONGODB_URI = process.env.MONGODB_URI || "mongodb://localhost/studio-api";
 const NODE_ENV = process.env.NODE_ENV || "development";
+const SHOULD_REFRESH_DATA = process.env.SHOULD_REFRESH_DATA.trim().toLowerCase() === "true" || false;
 const APP_URL = process.env.APP_URL || `http://localhost:${ PORT }`;
 
 /*
@@ -49,7 +50,9 @@ try {
 } catch (error) {
   console.error(`Error with connecting to MongoDB: ${ error }`);
 } finally {
-  if (NODE_ENV === "development") {
+  if (NODE_ENV === "development" && SHOULD_REFRESH_DATA) {
+    console.log("Refreshing data in local database.");
+
     // TODO: populate DB with fixtures here
     await createPeopleFixtures();
     await createProcessFixtures();
@@ -58,6 +61,8 @@ try {
 
     // populate sprint cache on startup
     await prepopulateSprintCache();
+  } else {
+    console.log("Not refreshing data in local database.");
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ import createPeopleFixtures from "./models/fixtures/populatePeople.js";
 import createProcessFixtures from "./models/fixtures/populateProcesses.js";
 import createProjectFixtures from "./models/fixtures/populateProjects.js";
 import createVenueFixtures from "./models/fixtures/populateVenues.js";
+import { prepopulateSprintCache } from "./controllers/sprints/sprintManager.js";
 
 /*
  Get environment variables.
@@ -54,6 +55,9 @@ try {
     await createProcessFixtures();
     await createProjectFixtures();
     await createVenueFixtures();
+
+    // populate sprint cache on startup
+    await prepopulateSprintCache();
   }
 }
 


### PR DESCRIPTION
This PR provides a hotfix for issue #13, where the Studio API would hit a rate limit for reading data from Google Spreadsheets. This was a problem when Sprint Logs are being read for the first time and the cache is empty. 

To temporarily resolve this issue, this PR:
1. Makes only 1 call per sheet to get all the data from it
2. Retries after 60 seconds if a rate limit is hit.

I have also requested our quota for Google Sheets to be raised so that we don't have to worry as much about this issue in the future.