### PR TITLE
Routes for first/last sig

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ import { venueRouter } from "./routes/venues.routes.js";
 import { projectRouter } from "./routes/projects.routes.js";
 import { sprintRouter } from "./routes/sprints.routes.js";
 import { slackRouter } from "./routes/slack.routes.js";
+import { dataRouter } from "./routes/data.routes.js";
 
 // fixtures for development
 import createPeopleFixtures, { isPeopleEmpty } from "./models/fixtures/populatePeople.js";
@@ -62,6 +63,7 @@ app.receiver.app.use('/venues', venueRouter);
 app.receiver.app.use('/projects', projectRouter);
 app.receiver.app.use('/sprints', sprintRouter);
 app.receiver.app.use('/slack', slackRouter);
+app.receiver.app.use('/data', dataRouter);
 
 app.receiver.app.use((req, res, next) => {
   res.header("Access-Control-Allow-Origin", "*");

--- a/models/fixtures/data/venueFixtures.js
+++ b/models/fixtures/data/venueFixtures.js
@@ -65,7 +65,7 @@ export const sigData = [
   {
     name: "Summer BBQ SIG",
     description: "Weekly SIG meeting for BBQ SIG",
-    day_of_week: "Monday",
+    day_of_week: "Wednesday",
     start_time: DateTime.fromISO("2000-01-01T10:00:00", { zone: "America/Chicago" }),
     end_time: DateTime.fromISO("2000-01-01T11:00:00", { zone: "America/Chicago" }),
     sig_head: "Haoqi Zhang",

--- a/routes/data.routes.js
+++ b/routes/data.routes.js
@@ -1,0 +1,25 @@
+import { Router } from "express";
+
+import createPeopleFixtures from "../models/fixtures/populatePeople.js";
+import createProcessFixtures from "../models/fixtures/populateProcesses.js";
+import createProjectFixtures from "../models/fixtures/populateProjects.js";
+import createVenueFixtures from "../models/fixtures/populateVenues.js";
+import { prepopulateSprintCache } from "../controllers/sprints/sprintManager.js";
+
+export const dataRouter = new Router();
+
+/**
+ * Refreshes all data in MongoDB when called.
+ */
+dataRouter.get("/refreshData", async (req, res) => {
+  // clear existing data and refresh with fixtures
+  await createPeopleFixtures();
+  await createProcessFixtures();
+  await createProjectFixtures();
+  await createVenueFixtures();
+
+  // populate sprint cache after data is refreshed
+  await prepopulateSprintCache();
+
+  res.send("Data refreshed.");
+});

--- a/routes/projects.routes.js
+++ b/routes/projects.routes.js
@@ -21,6 +21,35 @@ projectRouter.get("/", async (req, res) => {
   }
 });
 
+/**
+ * Get project information, given the name of the project.
+ */
+projectRouter.get("/projectByName", async (req, res) => {
+  try {
+    // fetch the person's name from the query that we want the sprint log for, and check if valid
+    let projName = req.query.projName;
+    if (projName === undefined) {
+      throw new Error("personName parameter not specified.");
+    }
+
+    // find project with projName
+    let relevantProj = await Project.findOne({ name: projName })
+      .populate('students')
+      .populate('sig_head')
+      .populate('faculty_mentor');
+
+    if (relevantProj !== null) {
+      res.json(relevantProj);
+    } else {
+      res.json({});
+    }
+  } catch (error) {
+    console.error(error)
+    res.send(`Error when fetching sprint log for person: ${ error }`);
+  }
+});
+
+
 // fetch project for student
 projectRouter.get("/fetchProjectForPerson", async (req, res) => {
   try {

--- a/routes/slack.routes.js
+++ b/routes/slack.routes.js
@@ -74,8 +74,8 @@ slackRouter.post("/sendMessageToProjChannel", async (req, res) => {
     channel: channelName,
     text: `Hey ${
       students.map((student) => {
-        return `@${ student.slack_id }`
-      }).join(" ")
+        return `${ student.name }`
+      }).join(", ")
     }! ${ message }`
   });
 

--- a/routes/slack.routes.js
+++ b/routes/slack.routes.js
@@ -32,6 +32,88 @@ slackRouter.get("/getAllPeople", async (req, res) => {
 });
 
 /**
+ * Sends a message to all project channels.
+ */
+slackRouter.post("/sendMessageToAllProjChannels", async (req, res) => {
+  // parse inputs
+  let message = (req.body.message ?? "").trim();
+
+  // fetch project info
+  let allProjects = await Project.find({}).populate('students');
+  if (allProjects === null) {
+    throw new Error(`no projects found`);
+  }
+
+  // iterate over each project and send message
+  let messagesToSend = [];
+  for (let project of allProjects) {
+    // get channel name
+    let channelName = project.slack_channel;
+
+    // get people and their names
+    let students = project.students.map((student) => {
+      return {
+        name: student.name,
+        slack_id: student.slack_id
+      }
+    });
+
+    // send message to channel
+    messagesToSend.push(app.client.chat.postMessage({
+      channel: channelName,
+      text: `Hey ${
+        students.map((student) => {
+          return `${ student.name }`
+        }).join(", ")
+      }! ${ message }`
+    }));
+  }
+
+  res.json(await Promise.all(messagesToSend));
+});
+
+/**
+ * Sends a message to all SIG channels.
+ */
+slackRouter.post("/sendMessageToAllSigChannels", async (req, res) => {
+  // parse inputs
+  let message = (req.body.message ?? "").trim();
+
+  // fetch project info
+  let allSigs = await SIG.find({}).populate("sig_members");
+  if (allSigs === null) {
+    throw new Error(`no projects found`);
+  }
+
+  // iterate over each project and send message
+  let messagesToSend = [];
+  for (let sig of allSigs) {
+    // get channel name
+    let channelName = sig.slack_channel;
+
+    // get people and their names
+    let students = sig.sig_members.map((student) => {
+      return {
+        name: student.name,
+        slack_id: student.slack_id
+      }
+    });
+
+    // send message to channel
+    messagesToSend.push(app.client.chat.postMessage({
+      channel: channelName,
+      text: `Hey ${
+        students.map((student) => {
+          return `${ student.name }`
+        }).join(", ")
+      }! ${ message }`
+    }));
+  }
+
+  res.json(await Promise.all(messagesToSend));
+});
+
+/**
  * Sends message to a project's Slack Channel.
  */
 slackRouter.post("/sendMessageToProjChannel", async (req, res) => {

--- a/routes/venues.routes.js
+++ b/routes/venues.routes.js
@@ -171,8 +171,8 @@ venueRouter.get("/sig/lastSig", async (req, res) => {
     );
 
     res.json({
-      start_time: finalSigStartTime,
-      end_time: finalSigEndTime
+      start_time: finalSigStartTime.toJSON(),
+      end_time: finalSigEndTime.toJSON()
     });
   } catch (error) {
     res.send(`Error when fetching last sig meetings: ${ error }`);

--- a/routes/venues.routes.js
+++ b/routes/venues.routes.js
@@ -5,6 +5,8 @@ import { Venue } from "../models/venues/venue.js";
 import { Studio } from "../models/venues/studio.js";
 import { SIG } from "../models/venues/sig.js";
 import { OfficeHours } from "../models/venues/officeHours.js";
+import { Project } from "../models/project/project.js";
+import { Sprint } from "../models/processes/sprints.js";
 
 export const venueRouter = new Router();
 
@@ -38,6 +40,145 @@ venueRouter.get("/sig", async (req, res) => {
   }
 });
 
+/**
+ * Fetches the start and end time of the first SIG meeting (the start of Sprint 1) for a project.
+ * // TODO: I don't think this is quite right
+ * // TODO: this should be a separate controller
+ */
+venueRouter.get("/sig/firstSig", async (req, res) => {
+  try {
+    // parse inputs
+    let projName = (req.query.projName ?? "").trim();
+
+    // fetch project info
+    let relevantProject = await Project.findOne( { name: projName })
+      .populate('students')
+      .populate('sig_head')
+      .populate('faculty_mentor');
+    if (relevantProject === null) {
+      throw new Error(`no project found for ${ projName }`);
+    }
+
+    // get SIG info for project name
+    let sigName = relevantProject.sig_name;
+    let relevantSigVenueInfo = await SIG.findOne({
+      name: {
+        "$regex": sigName,
+        "$options": "i"
+      }
+    });
+    if (relevantSigVenueInfo === null) {
+      throw new Error(`no SIG found for ${ projName }`);
+    }
+
+    // get processes to figure out when last sprint starts
+    let relevantProcess = await Sprint.findOne({
+      name: "Sprint 1"
+    });
+    if (relevantProcess === null) {
+      throw new Error(`no sprint info found for Sprint 1`);
+    }
+
+    // compute day for venue by first getting the start of the week
+    let weekOfLastSig = new Date(relevantProcess.start_day);
+    weekOfLastSig.setDate(
+      relevantProcess.start_day.getDate() - relevantProcess.start_day.getDay()
+    );
+
+    // shift day based on day of week when SIG is
+    let firstSigDate = new Date(weekOfLastSig);
+    firstSigDate.setDate(
+      firstSigDate.getDate() + dayOfWeekToIndex(relevantSigVenueInfo.day_of_week)
+    );
+    let firstSigStartTime = new Date(firstSigDate);
+    firstSigStartTime.setHours(
+      relevantSigVenueInfo.start_time.getHours(),
+      relevantSigVenueInfo.start_time.getMinutes()
+    );
+    let finalSigEndTime = new Date(firstSigDate);
+    finalSigEndTime.setHours(
+      relevantSigVenueInfo.end_time.getHours(),
+      relevantSigVenueInfo.end_time.getMinutes()
+    );
+
+    res.json({
+      start_time: firstSigStartTime,
+      end_time: finalSigEndTime
+    });
+  } catch (error) {
+    res.send(`Error when fetching last sig meetings: ${ error }`);
+  }
+});
+
+/**
+ * Fetches the start and end time of the last SIG meeting (the start of Sprint 5) for a project.
+ * TODO: this breaks for fall quarter where sprint 5 is 2 weeks and there is a SIG meeting in between.
+ */
+venueRouter.get("/sig/lastSig", async (req, res) => {
+  try {
+    // parse inputs
+    let projName = (req.query.projName ?? "").trim();
+
+    // fetch project info
+    let relevantProject = await Project.findOne( { name: projName })
+      .populate('students')
+      .populate('sig_head')
+      .populate('faculty_mentor');
+    if (relevantProject === null) {
+      throw new Error(`no project found for ${ projName }`);
+    }
+
+    // get SIG info for project name
+    let sigName = relevantProject.sig_name;
+    let relevantSigVenueInfo = await SIG.findOne({
+      name: {
+        "$regex": sigName,
+        "$options": "i"
+      }
+    });
+    if (relevantSigVenueInfo === null) {
+      throw new Error(`no SIG found for ${ projName }`);
+    }
+
+    // get processes to figure out when last sprint starts
+    let relevantProcess = await Sprint.findOne({
+      name: "Sprint 5"
+    });
+    if (relevantProcess === null) {
+      throw new Error(`no sprint info found for Sprint 5`);
+    }
+
+    // compute day for venue by first getting the start of the week
+    let weekOfLastSig = new Date(relevantProcess.start_day);
+    weekOfLastSig.setDate(
+      relevantProcess.start_day.getDate() - relevantProcess.start_day.getDay()
+    );
+
+    // shift day based on day of week when SIG is
+    let finalSigDate = new Date(weekOfLastSig);
+    finalSigDate.setDate(
+      finalSigDate.getDate() + dayOfWeekToIndex(relevantSigVenueInfo.day_of_week)
+    );
+    let finalSigStartTime = new Date(finalSigDate);
+    finalSigStartTime.setHours(
+      relevantSigVenueInfo.start_time.getHours(),
+      relevantSigVenueInfo.start_time.getMinutes()
+    );
+    let finalSigEndTime = new Date(finalSigDate);
+    finalSigEndTime.setHours(
+      relevantSigVenueInfo.end_time.getHours(),
+      relevantSigVenueInfo.end_time.getMinutes()
+    );
+
+    res.json({
+      start_time: finalSigStartTime,
+      end_time: finalSigEndTime
+    });
+  } catch (error) {
+    res.send(`Error when fetching last sig meetings: ${ error }`);
+  }
+});
+
 // fetch all office hour times
 venueRouter.get("/officehours", async (req, res) => {
   try {
@@ -49,3 +190,38 @@ venueRouter.get("/officehours", async (req, res) => {
 });
 
 // TODO: implement a generic venue route that returns whatever venue is asked for
+
+/**
+ * Converts a string day of the week to an integer index.
+ *
+ * @param dayString
+ * @return {number}
+ */
+const dayOfWeekToIndex = function (dayString) {
+  let dayIndex;
+  switch (dayString) {
+    case "Sunday":
+      dayIndex = 0;
+      break;
+    case "Monday":
+      dayIndex = 1;
+      break;
+    case "Tuesday":
+      dayIndex = 2;
+      break;
+    case "Wednesday":
+      dayIndex = 3;
+      break;
+    case "Thursday":
+      dayIndex = 4;
+      break;
+    case "Friday":
+      dayIndex = 5;
+      break;
+    case "Saturday":
+      dayIndex = 6;
+      break;
+  }
+
+  return dayIndex;
+};


### PR DESCRIPTION
This PR adds routes for getting first and last SIG meetings. It also adds routes  for sending slack messages to a SIG channel, to reset data using fixtures, and to get project info given a name.

Closes #18 