### PR TITLE
clearing old data when /refreshData route is used

### DIFF
--- a/models/fixtures/populateProcesses.js
+++ b/models/fixtures/populateProcesses.js
@@ -31,9 +31,7 @@ const createSprintProcessDocuments = async () => {
  */
 export default async function main() {
   // remove all old documents
-  if (process.env.NODE_ENV === "development") {
-    await Process.deleteMany({}).exec();
-  }
+  await Process.deleteMany({}).exec();
 
   // populate new documents
   await createSprintProcessDocuments();

--- a/models/fixtures/populateProjects.js
+++ b/models/fixtures/populateProjects.js
@@ -52,9 +52,7 @@ const createProjectDocuments = async () => {
  */
 export default async function main() {
   // remove all old documents
-  if (process.env.NODE_ENV === "development") {
-    await Project.deleteMany({}).exec();
-  }
+  await Project.deleteMany({}).exec();
 
   // populate new documents
   await createProjectDocuments();

--- a/models/fixtures/populateVenues.js
+++ b/models/fixtures/populateVenues.js
@@ -99,9 +99,7 @@ const createOfficeHoursDocuments = async () => {
  */
 export default async function main() {
   // remove all old documents
-  if (process.env.NODE_ENV === "development") {
-    await Venue.deleteMany({}).exec();
-  }
+  await Venue.deleteMany({}).exec();
 
   // populate new documents
   await createStudioDocuments();


### PR DESCRIPTION
Old data was not being cleared in production when refreshData was called by a post request. This PR cleans up old data before re-populating it with the hardcoded fixtures.