### PR TITLE
Slack Handle Notification

### DIFF
--- a/models/fixtures/data/peopleFixtures.js
+++ b/models/fixtures/data/peopleFixtures.js
@@ -2,13 +2,13 @@ export const facultyData = [
   {
     name: "Haoqi Zhang",
     email: "haoqi@northwestern.edu",
-    slack_id: "haoqi-zhang",
+    slack_id: (process.env.NODE_ENV === "development") ? "U03EA817FU3" : "U0E2XS3LL",
     sig_lead: "Summer BBQ"
   },
   {
     name: "Nell O'Rourke",
     email: "nell@northwestern.edu",
-    slack_id: "nell-orourke",
+    slack_id: "U2MGUUFK5",
     sig_lead: "Summer BEACH"
   }
 ];
@@ -17,7 +17,7 @@ export const phdStudentData = [
   {
     name: "Leesha Maliakal Shah",
     email: "lmalishah@u.northwestern.edu",
-    slack_id: "leesha-maliakal-shah",
+    slack_id: "U0E33DF5F",
     sig_lead: "Agile Research Studios",
     sig_member: "Summer BBQ",
     faculty_mentor: "Haoqi Zhang"
@@ -25,7 +25,7 @@ export const phdStudentData = [
   {
     name: "Gobi Dasu",
     email: "gobi@northwestern.edu",
-    slack_id: "gobi-dasu",
+    slack_id: "UCCCTJGG4",
     sig_lead: "Readily Available Learning Experiences",
     sig_member: "Summer BBQ",
     faculty_mentor: "Haoqi Zhang"
@@ -33,7 +33,7 @@ export const phdStudentData = [
   {
     name: "Ryan Louie",
     email: "ryan@northwestern.edu",
-    slack_id: "ryan-louie",
+    slack_id: "U6YKFU5UH",
     sig_lead: "Collective Experiences",
     sig_member: "Summer BBQ",
     faculty_mentor: "Haoqi Zhang"
@@ -41,7 +41,7 @@ export const phdStudentData = [
   {
     name: "Kapil Garg",
     email: "kapil@northwestern.edu",
-    slack_id: "kapil-garg",
+    slack_id: (process.env.NODE_ENV === "development") ? "U033BDY8A1E" : "U0G17CVCZ",
     sig_lead: "Networked Orchestration Technologies",
     sig_member: "Summer BBQ",
     faculty_mentor: "Haoqi Zhang"
@@ -49,7 +49,7 @@ export const phdStudentData = [
   {
     name: "Harrison Kwik",
     email: "harrison@northwestern.edu",
-    slack_id: "harrison-kwik",
+    slack_id: "UHQQKMFSM",
     sig_lead: "Context-Aware Metacognitive Practice",
     sig_member: "Summer BBQ",
     faculty_mentor: "Nell O'Rourke"
@@ -61,7 +61,7 @@ export const nonPhdStudentData = [
   {
     name: "Molly Pribble",
     email: "molly@northwestern.edu",
-    slack_id: "molly-pribble",
+    slack_id: "U01FQMT8F2R",
     sig_member: "Agile Research Studios",
     sig_head: "Leesha Maliakal Shah"
   },
@@ -70,21 +70,21 @@ export const nonPhdStudentData = [
   {
     name: "Jason Friedman",
     email: "jason@northwestern.edu",
-    slack_id: "jason-friedman",
+    slack_id: (process.env.NODE_ENV === "development") ? "U03EA8ADL3D" : "U01QTS34NUB",
     sig_member: "Networked Orchestration Technologies",
     sig_head: "Kapil Garg"
   },
   {
     name: "Hang Yin",
     email: "hang@northwestern.edu",
-    slack_id: "hang-yin",
+    slack_id: (process.env.NODE_ENV === "development") ? "U03E7B5L1E1" : "U01R6955UTT",
     sig_member: "Networked Orchestration Technologies",
     sig_head: "Kapil Garg"
   },
   {
     name: "Sydney Smith",
     email: "sydneysmith2022@u.northwestern.edu",
-    slack_id: "sydney-smith",
+    slack_id: (process.env.NODE_ENV === "development") ? "U03E3K10XSS" : "U02P9SKPBA5",
     sig_member: "Networked Orchestration Technologies",
     sig_head: "Kapil Garg"
   },
@@ -93,28 +93,28 @@ export const nonPhdStudentData = [
   {
     name: "Parveen Dhanoa",
     email: "neenadhanoa2023@u.northwestern.edu",
-    slack_id: "parveen-dhanoa",
+    slack_id: "U02NU9NTJ3F",
     sig_member: "Collective Experiences",
     sig_head: "Ryan Louie"
   },
   {
     name: "Richard Lam",
     email: "richardlam2024@u.northwestern.edu",
-    slack_id: "richard-lam",
+    slack_id: "UEQ6YS7NF",
     sig_member: "Collective Experiences",
     sig_head: "Ryan Louie"
   },
   {
     name: "Yvan Chu",
     email: "yvan@u.northwestern.edu",
-    slack_id: "yvan-chu",
+    slack_id: "U02PLV6HBMW",
     sig_member: "Collective Experiences",
     sig_head: "Ryan Louie"
   },
   {
     name: "Cindy Hu",
     email: "cindyhu2023@u.northwestern.edu",
-    slack_id: "cindy-hu",
+    slack_id: "U024DKZ7WQJ",
     sig_member: "Collective Experiences",
     sig_head: "Ryan Louie"
   },
@@ -123,14 +123,14 @@ export const nonPhdStudentData = [
   {
     name: "Alexandra Andreiu",
     email: "alexandraandreiu2023@u.northwestern.edu",
-    slack_id: "alexandra-andreiu",
+    slack_id: "U035RKR6UGL",
     sig_member: "Readily Available Learning Experiences",
     sig_head: "Gobi Dasu"
   },
   {
     name: "Jonathan Liu",
     email: "JonathanLiu2022.1@u.northwestern.edu",
-    slack_id: "jonathan-liu",
+    slack_id: "U01R694ECJV",
     sig_member: "Readily Available Learning Experiences",
     sig_head: "Gobi Dasu"
   },
@@ -139,14 +139,14 @@ export const nonPhdStudentData = [
   {
     name: "Lauren Bichelmeir",
     email: "laurenbichelmeir2023@u.northwestern.edu",
-    slack_id: "lauren-bichelmeir",
+    slack_id: "U035GLA80S2",
     sig_member: "Context-Aware Metacognitive Practice",
     sig_head: "Harrison Kwik"
   },
   {
     name: "Amy Guo",
     email: "amyguo2023@u.northwestern.edu",
-    slack_id: "amy-guo",
+    slack_id: "U035GLAFZGE",
     sig_member: "Context-Aware Metacognitive Practice",
     sig_head: "Harrison Kwik"
   }

--- a/routes/slack.routes.js
+++ b/routes/slack.routes.js
@@ -34,6 +34,7 @@ slackRouter.get("/getAllPeople", async (req, res) => {
 /**
  * Sends a message to all project channels.
  */
+// TODO: this should really call the same function that sends data to a single project channel.
 slackRouter.post("/sendMessageToAllProjChannels", async (req, res) => {
   // parse inputs
   let message = (req.body.message ?? "").trim();
@@ -61,11 +62,7 @@ slackRouter.post("/sendMessageToAllProjChannels", async (req, res) => {
     // send message to channel
     messagesToSend.push(app.client.chat.postMessage({
       channel: channelName,
-      text: `Hey ${
-        students.map((student) => {
-          return `${ student.name }`
-        }).join(", ")
-      }! ${ message }`
+      text: `Hey ${formatPeopleForSlackMessage(students)}! ${ message }`
     }));
   }
 
@@ -75,6 +72,7 @@ slackRouter.post("/sendMessageToAllProjChannels", async (req, res) => {
 /**
  * Sends a message to all SIG channels.
  */
+// TODO: this should really call the same function that sends data to a single sig channel.
 slackRouter.post("/sendMessageToAllSigChannels", async (req, res) => {
   // parse inputs
   let message = (req.body.message ?? "").trim();
@@ -102,11 +100,7 @@ slackRouter.post("/sendMessageToAllSigChannels", async (req, res) => {
     // send message to channel
     messagesToSend.push(app.client.chat.postMessage({
       channel: channelName,
-      text: `Hey ${
-        students.map((student) => {
-          return `${ student.name }`
-        }).join(", ")
-      }! ${ message }`
+      text: `Hey ${formatPeopleForSlackMessage(students)}! ${ message }`
     }));
   }
 
@@ -116,6 +110,7 @@ slackRouter.post("/sendMessageToAllSigChannels", async (req, res) => {
 /**
  * Sends message to a project's Slack Channel.
  */
+// TODO: factor this out into a controller
 slackRouter.post("/sendMessageToProjChannel", async (req, res) => {
   // TODO: check if inputs are valid
   // parse inputs
@@ -155,11 +150,7 @@ slackRouter.post("/sendMessageToProjChannel", async (req, res) => {
   // send message to channel
   const result = await app.client.chat.postMessage({
     channel: channelName,
-    text: `Hey ${
-      students.map((student) => {
-        return `${ student.name }`
-      }).join(", ")
-    }! ${ message }`
+    text: `Hey ${formatPeopleForSlackMessage(students)}! ${ message }`
   });
 
   // return result of slack message
@@ -169,6 +160,7 @@ slackRouter.post("/sendMessageToProjChannel", async (req, res) => {
 /**
  * Sends message to a SIG's Slack channel.
  */
+// TODO: factor this out into a controller
 slackRouter.post("/sendMessageToSigChannel", async (req, res) => {
   // TODO: check if inputs are valid
   // parse inputs
@@ -199,11 +191,7 @@ slackRouter.post("/sendMessageToSigChannel", async (req, res) => {
   // send message to channel
   const result = await app.client.chat.postMessage({
     channel: channelName,
-    text: `Hey ${
-      students.map((student) => {
-        return `${ student.name }`
-      }).join(", ")
-    }! ${ message }`
+    text: `Hey ${formatPeopleForSlackMessage(students)}! ${ message }`
   });
 
   // return result of slack message
@@ -225,3 +213,15 @@ slackRouter.post("/sendMessageToCommitteeChannel", async (req, res) => {
 slackRouter.post("/sendMessageToPerson", async (req, res) => {
   res.json({});
 });
+
+
+/**
+ * Returns a list of slack id's when provided a list of people objects, which can be used to ping each person in a channel or direct message in Slack.
+ * @param peopleList list of people objects. each person must contain a slack_id field.
+ * @returns {string} string with each person's slack_id concatenated together.
+ */
+const formatPeopleForSlackMessage = (peopleList) => {
+  return peopleList.map((person) => {
+    return `<@${ person.slack_id }>`
+  }).join(" ");
+}


### PR DESCRIPTION
With this PR, all Slack messages sent to a project channel or SIG channel will now mention (e.g., "@kapil") the student's of that project/sig by their slack ID. This PR also adds the ability to send a DM or group DM, given a list of people's names.